### PR TITLE
[WIP] Clean Up Ctest4J Runner Interface and Merge Common code to Runner Interface

### DIFF
--- a/ctest4j-junit4/src/main/java/edu/illinois/CTestJUnitRunner.java
+++ b/ctest4j-junit4/src/main/java/edu/illinois/CTestJUnitRunner.java
@@ -214,7 +214,7 @@ public class CTestJUnitRunner extends BlockJUnit4ClassRunner implements CTestRun
                 } catch (Throwable throwable) {
                     fromTestThrowable = throwable;
                 } finally {
-                    if (shouldThorwException(fromTestThrowable)) {
+                    if (shouldThrowException(fromTestThrowable)) {
                         throw fromTestThrowable;
                     }
                     ConfigUsage.bufferForUpdate(configUsage, testClassName, method.getName());
@@ -275,7 +275,7 @@ public class CTestJUnitRunner extends BlockJUnit4ClassRunner implements CTestRun
 
     @Override
     public Set<String> getUnionClassParameters(Set<String> classLevelParameters, String classConfigFile, String classRegex) throws IOException {
-        classLevelParameters.addAll(getClasssParametersFromMappingFile(classConfigFile));
+        classLevelParameters.addAll(getClassParametersFromMappingFile(classConfigFile));
         if (!classRegex.isEmpty()) {
             classLevelParameters.addAll(getParametersFromRegex(classRegex));
         }

--- a/ctest4j-junit5/src/main/java/edu/illinois/CTestJUnit5Extension.java
+++ b/ctest4j-junit5/src/main/java/edu/illinois/CTestJUnit5Extension.java
@@ -109,7 +109,7 @@ public class CTestJUnit5Extension implements CTestRunner, ExecutionCondition,
 
     @Override
     public Set<String> getUnionClassParameters(Set<String> classLevelParameters, String classConfigFile, String classRegex) throws IOException {
-        classLevelParameters.addAll(getClasssParametersFromMappingFile(classConfigFile));
+        classLevelParameters.addAll(getClassParametersFromMappingFile(classConfigFile));
         if (!classRegex.isEmpty()) {
             classLevelParameters.addAll(getParametersFromRegex(classRegex));
         }

--- a/ctest4j-testng/src/main/java/edu/illinois/CTestListener.java
+++ b/ctest4j-testng/src/main/java/edu/illinois/CTestListener.java
@@ -100,7 +100,7 @@ public class CTestListener implements CTestRunner, IClassListener, IInvokedMetho
 
     @Override
     public Set<String> getUnionClassParameters(Set<String> classLevelParameters, String classConfigFile, String classRegex) throws IOException {
-        classLevelParameters.addAll(getClasssParametersFromMappingFile(classConfigFile));
+        classLevelParameters.addAll(getClassParametersFromMappingFile(classConfigFile));
         if (!classRegex.isEmpty()) {
             classLevelParameters.addAll(getParametersFromRegex(classRegex));
         }


### PR DESCRIPTION
- [ ] Clean up the existing Ctest4j runner interface;
- [ ] Extract the common functions from JUnit4/JUnit5/TestNG runner to the Ctest4j runner interface.